### PR TITLE
Unify PatchBlocksInput, kill string passthrough, remove SchemaIOTool from editor

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -29,6 +29,7 @@ import {
   CreateRecordInput,
   ImportAssetFromUrlInput,
   ImportSchemaInput,
+  PatchBlocksInput,
   ReindexSearchInput,
   ReorderInput,
   SearchInput as SearchContentInput,
@@ -123,13 +124,6 @@ const UpdateRecordInput = Schema.Struct({
   data: Schema.optionalWith(JsonRecord, { default: () => ({}) }),
 });
 
-const PatchBlocksInput = Schema.Struct({
-  recordId: Schema.String,
-  modelApiKey: Schema.String,
-  fieldApiKey: Schema.String,
-  value: Schema.optional(Schema.Unknown),
-  blocks: Schema.Record({ key: Schema.String, value: Schema.NullOr(Schema.Unknown) }),
-});
 
 const DeleteRecordInput = Schema.Struct({
   recordId: Schema.String,
@@ -379,18 +373,17 @@ You can target block IDs from either:
 - nested structured_text sub-fields stored inside those blocks
 
 Patch map semantics for each block ID:
-- string value (the block ID) → keep block unchanged
 - object with field overrides → merge into existing block (only specified fields updated)
 - null → delete block and auto-prune from the relevant DAST tree
 
-Block IDs not in the patch map are kept unchanged.
+Block IDs not in the patch map are kept unchanged. Omit a block ID to leave it as-is.
 
 If a nested block ID appears in multiple nested structured_text locations, the tool will fail and ask you to patch the parent block explicitly.
 
 Optionally provide a new top-level DAST \`value\`. If omitted, the existing DAST is preserved (with deleted top-level blocks auto-pruned).
 
 Example — update one block's description, delete another, keep the rest:
-{ blocks: { "block-1": "block-1", "block-2": { "description": "New text" }, "block-3": null } }`, PatchBlocksInput.fields);
+{ blocks: { "block-2": { "description": "New text" }, "block-3": null } }`, PatchBlocksInput.fields);
 const DeleteRecordTool = cmsTool("delete_record", "Delete a record", DeleteRecordInput.fields);
 const GetRecordTool = cmsTool("get_record", "Get a single record by modelApiKey + recordId. Useful after search_content when you need the full materialized record, including structured_text fields, before patch_blocks or update_record.", GetRecordInput.fields);
 const QueryRecordsTool = cmsTool("query_records", "List records for a model. Structured_text fields are materialized for inspection, including nested blocks inside parent block fields. Useful for finding record IDs before update_record, patch_blocks, publish_records, or record_versions.", QueryRecordsInput.fields);
@@ -553,7 +546,6 @@ const EditorTools = [
   ImportAssetFromUrlTool,
   ListAssetsTool,
   ReplaceAssetTool,
-  SchemaIOTool,
   SearchContentTool,
   GetSiteSettingsTool,
   UpdateSiteSettingsTool,

--- a/src/services/record-service.ts
+++ b/src/services/record-service.ts
@@ -1288,26 +1288,10 @@ export function patchBlocksForField(body: PatchBlocksInput, actor?: RequestActor
           });
         }
       } else if (typeof patchValue === "string") {
-        // Keep unchanged — verify it exists
-        if (!Object.hasOwn(existingBlocks, blockId)) {
-          let nestedMatched = false;
-          for (const topLevelBlock of Object.values(mergedBlocks)) {
-            const result = applyPatchToNestedStructuredText(topLevelBlock, blockId, patchValue);
-            if (result.ambiguous) {
-              return yield* new ValidationError({
-                message: `Block '${blockId}' matched multiple nested structured_text locations in field '${body.fieldApiKey}'. Patch the parent block explicitly instead.`,
-                field: body.fieldApiKey,
-              });
-            }
-            nestedMatched = nestedMatched || result.applied;
-          }
-          if (!nestedMatched) {
-            return yield* new ValidationError({
-              message: `Block '${blockId}' does not exist in field '${body.fieldApiKey}'.`,
-              field: body.fieldApiKey,
-            });
-          }
-        }
+        return yield* new ValidationError({
+          message: `Invalid patch value for block '${blockId}': use an object to update fields, null to delete, or omit the key to keep unchanged.`,
+          field: body.fieldApiKey,
+        });
       } else if (typeof patchValue === "object" && !Array.isArray(patchValue)) {
         // Partial merge
         if (!Object.hasOwn(existingBlocks, blockId)) {

--- a/test/patch-blocks.test.ts
+++ b/test/patch-blocks.test.ts
@@ -133,7 +133,7 @@ describe("patch_blocks — partial block updates", () => {
     expect(blockItems).not.toContain("v2");
   });
 
-  it("keeps block unchanged with string passthrough", async () => {
+  it("rejects string passthrough with a clear error message", async () => {
     const record = await createGuideWithVenues();
 
     const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
@@ -144,16 +144,10 @@ describe("patch_blocks — partial block updates", () => {
         v3: { name: "Dill Restaurant" },
       },
     });
-    expect(patchRes.status).toBe(200);
-
-    const blocks = await getBlocks(record.id);
-    expect(blocks).toHaveLength(3);
-
-    const v1 = blocks.find((b) => b.id === "v1");
-    const v3 = blocks.find((b) => b.id === "v3");
-    expect(v1?.name).toBe("Grillid");
-    expect(v3?.name).toBe("Dill Restaurant");
-    expect(v3?.description).toBe("Nordic cuisine");
+    expect(patchRes.status).toBe(400);
+    const body = await patchRes.json();
+    expect(body.error).toContain("Invalid patch value for block 'v1'");
+    expect(body.error).toContain("use an object to update fields, null to delete, or omit the key to keep unchanged");
   });
 
   it("allows combined update + delete in one call", async () => {
@@ -206,12 +200,11 @@ describe("patch_blocks — partial block updates", () => {
   it("works via MCP tool input shape", async () => {
     const record = await createGuideWithVenues();
 
-    // Same payload shape as MCP tool would use
+    // Same payload shape as MCP tool would use — omit v1 to keep unchanged
     const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
       modelApiKey: "guide",
       fieldApiKey: "content",
       blocks: {
-        v1: "v1",
         v2: { name: "BBB", description: "Best hot dogs" },
         v3: null,
       },


### PR DESCRIPTION
## Summary
- Import canonical `PatchBlocksInput` from `input-schemas.ts` instead of maintaining a local copy in `server.ts` (stricter `NonEmptyString` validation, single source of truth for when `append`/`order` fields are added)
- Remove string passthrough from `patch_blocks` — omitting a key already means "keep unchanged", the string form was a redundant concept that confused agents
- Remove `SchemaIOTool` from `EditorTools` — schema import/export is an admin operation
- Update tool description and example

## Test plan
- [x] String passthrough now returns 400 with clear error message
- [x] Object patches and null deletes work unchanged
- [x] Omitted block IDs kept unchanged
- [x] MCP tool input shape test updated (omit instead of string passthrough)
- [x] patch-blocks tests pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)