### PR TITLE
Add append array to patch_blocks for new block insertion

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -387,8 +387,13 @@ If a nested block ID appears in multiple nested structured_text locations, the t
 
 Optionally provide a new top-level DAST \`value\`. If omitted, the existing DAST is preserved (with deleted top-level blocks auto-pruned).
 
+Use \`append\` to insert new blocks without reconstructing the DAST. Each entry is a record with \`_type\` and field values. New block IDs are auto-generated, DAST block nodes are appended to the end, and the response includes \`_appendedIds\`. Cannot be combined with \`value\`.
+
 Example — update one block's description, delete another, keep the rest:
-{ blocks: { "block-2": { "description": "New text" }, "block-3": null } }`, PatchBlocksInput.fields);
+{ blocks: { "block-2": { "description": "New text" }, "block-3": null } }
+
+Example — append a new block while patching an existing one:
+{ blocks: { "block-2": { "description": "Updated" } }, append: [{ "_type": "venue", "name": "New Place" }] }`, PatchBlocksInput.fields);
 const DeleteRecordTool = cmsTool("delete_record", "Delete a record", DeleteRecordInput.fields);
 const GetRecordTool = cmsTool("get_record", "Get a single record by modelApiKey + recordId. Useful after search_content when you need the full materialized record, including structured_text fields, before patch_blocks or update_record.", GetRecordInput.fields);
 const QueryRecordsTool = cmsTool("query_records", "List records for a model. Structured_text fields are materialized for inspection, including nested blocks inside parent block fields. Useful for finding record IDs before update_record, patch_blocks, set_publish_status, or record_versions.", QueryRecordsInput.fields);
@@ -593,6 +598,7 @@ Field value formats (composite types):
 Structured text editing notes:
   - patch_blocks can target both top-level blocks and nested blocks inside structured_text sub-fields.
   - If the same nested block ID exists in multiple locations, patch_blocks will ask you to patch the parent block explicitly.
+  - patch_blocks supports an \`append\` array to insert new blocks without rebuilding the DAST. Each entry needs \`_type\` plus field values. New block nodes are appended to the end of the document. The response includes \`_appendedIds\` with the generated IDs.
   - get_record is the fastest way to inspect one known record's full materialized structured_text after search_content returns its id.
   - query_records materializes structured_text fields for inspection; on published records, _published_snapshot remains useful as a raw snapshot of what is live.
 

--- a/src/services/input-schemas.ts
+++ b/src/services/input-schemas.ts
@@ -285,6 +285,7 @@ export const PatchBlocksInput = Schema.Struct({
   fieldApiKey: Schema.NonEmptyString,
   value: Schema.optional(Schema.Unknown),
   blocks: Schema.Record({ key: Schema.String, value: Schema.NullOr(Schema.Unknown) }),
+  append: Schema.optional(Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown }))),
 });
 export type PatchBlocksInput = typeof PatchBlocksInput.Type;
 

--- a/src/services/record-service.ts
+++ b/src/services/record-service.ts
@@ -1334,17 +1334,50 @@ export function patchBlocksForField(body: PatchBlocksInput, actor?: RequestActor
       }
     }
 
+    // Process append entries — add new blocks with auto-generated IDs
+    const appendedIds: string[] = [];
+    for (const entry of body.append ?? []) {
+      const id = generateId();
+      appendedIds.push(id);
+      mergedBlocks[id] = entry as Record<string, unknown>;
+    }
+
     // Build final DAST value
     let finalDastValue: unknown;
-    if (body.value !== undefined) {
+    if (body.value !== undefined && appendedIds.length > 0) {
+      return yield* new ValidationError({
+        message: "Cannot use both 'value' and 'append' — appended blocks need auto-generated DAST nodes which conflict with a custom DAST value.",
+        field: body.fieldApiKey,
+      });
+    } else if (body.value !== undefined) {
       finalDastValue = body.value;
-    } else if (blockIdsToDelete.size > 0) {
-      // Auto-prune deleted blocks from existing DAST
+    } else if (blockIdsToDelete.size > 0 || appendedIds.length > 0) {
+      // Clone existing DAST, prune deleted blocks, append new block nodes
       const existingDast = existingEnvelope.value as {
         schema: string;
         document: { type: string; children: readonly unknown[] };
       };
-      finalDastValue = pruneBlockNodes(existingDast, blockIdsToDelete);
+      const pruned = blockIdsToDelete.size > 0
+        ? pruneBlockNodes(existingDast, blockIdsToDelete)
+        : existingDast;
+      if (appendedIds.length > 0) {
+        const prunedDoc = pruned as {
+          schema: string;
+          document: { type: string; children: readonly unknown[] };
+        };
+        finalDastValue = {
+          ...prunedDoc,
+          document: {
+            ...prunedDoc.document,
+            children: [
+              ...prunedDoc.document.children,
+              ...appendedIds.map((id) => ({ type: "block", item: id })),
+            ],
+          },
+        };
+      } else {
+        finalDastValue = pruned;
+      }
     } else {
       finalDastValue = existingEnvelope.value;
     }
@@ -1410,11 +1443,15 @@ export function patchBlocksForField(body: PatchBlocksInput, actor?: RequestActor
 
     const updatedRecord = yield* selectById(tableName, body.recordId);
     if (!updatedRecord) return null;
-    return yield* materializeRecordStructuredTextFields({
+    const materialized = yield* materializeRecordStructuredTextFields({
       modelApiKey: model.api_key,
       record: normalizeBooleanFields(updatedRecord, modelFields),
       fields: modelFields,
     });
+    if (materialized && appendedIds.length > 0) {
+      return { ...materialized, _appendedIds: appendedIds };
+    }
+    return materialized;
   });
 }
 

--- a/test/patch-blocks.test.ts
+++ b/test/patch-blocks.test.ts
@@ -251,4 +251,180 @@ describe("patch_blocks — partial block updates", () => {
     expect(content.value.document.children[1].type).toBe("paragraph");
     expect(content.value.document.children[2].item).toBe("v1");
   });
+
+  // ── append tests ──
+
+  it("appends a single new block to existing structured_text", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {},
+      append: [{ _type: "venue", name: "Messinn", description: "Fish stew" }],
+    });
+    expect(patchRes.status).toBe(200);
+
+    const result = await patchRes.json();
+    expect(result._appendedIds).toHaveLength(1);
+    const newId = result._appendedIds[0];
+
+    // Block exists in DB
+    const blocks = await getBlocks(record.id);
+    expect(blocks).toHaveLength(4);
+    const newBlock = blocks.find((b) => b.id === newId);
+    expect(newBlock?.name).toBe("Messinn");
+    expect(newBlock?.description).toBe("Fish stew");
+
+    // DAST has 4 block nodes, new one at end
+    const content = typeof result.content === "string" ? JSON.parse(result.content) : result.content;
+    expect(content.value.document.children).toHaveLength(4);
+    expect(content.value.document.children[3].type).toBe("block");
+    expect(content.value.document.children[3].item).toBe(newId);
+  });
+
+  it("appends multiple new blocks", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {},
+      append: [
+        { _type: "venue", name: "Messinn", description: "Fish stew" },
+        { _type: "venue", name: "Snaps", description: "Nordic bistro" },
+      ],
+    });
+    expect(patchRes.status).toBe(200);
+
+    const result = await patchRes.json();
+    expect(result._appendedIds).toHaveLength(2);
+
+    const blocks = await getBlocks(record.id);
+    expect(blocks).toHaveLength(5);
+
+    const content = typeof result.content === "string" ? JSON.parse(result.content) : result.content;
+    expect(content.value.document.children).toHaveLength(5);
+    expect(content.value.document.children[3].item).toBe(result._appendedIds[0]);
+    expect(content.value.document.children[4].item).toBe(result._appendedIds[1]);
+  });
+
+  it("appends + patches existing blocks in the same call", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {
+        v1: { description: "Updated fine dining" },
+      },
+      append: [{ _type: "venue", name: "Messinn", description: "Fish stew" }],
+    });
+    expect(patchRes.status).toBe(200);
+
+    const result = await patchRes.json();
+    expect(result._appendedIds).toHaveLength(1);
+
+    const blocks = await getBlocks(record.id);
+    expect(blocks).toHaveLength(4);
+    expect(blocks.find((b) => b.id === "v1")?.description).toBe("Updated fine dining");
+    expect(blocks.find((b) => b.id === result._appendedIds[0])?.name).toBe("Messinn");
+  });
+
+  it("appends + deletes existing blocks in the same call", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {
+        v2: null,
+      },
+      append: [{ _type: "venue", name: "Messinn", description: "Fish stew" }],
+    });
+    expect(patchRes.status).toBe(200);
+
+    const result = await patchRes.json();
+    expect(result._appendedIds).toHaveLength(1);
+
+    const blocks = await getBlocks(record.id);
+    expect(blocks).toHaveLength(3); // 3 original - 1 deleted + 1 appended
+    expect(blocks.find((b) => b.id === "v2")).toBeUndefined();
+    expect(blocks.find((b) => b.id === result._appendedIds[0])?.name).toBe("Messinn");
+
+    // DAST: v2 pruned, new block appended
+    const content = typeof result.content === "string" ? JSON.parse(result.content) : result.content;
+    const items = content.value.document.children.map((c: Record<string, unknown>) => c.item).filter(Boolean);
+    expect(items).toContain("v1");
+    expect(items).not.toContain("v2");
+    expect(items).toContain("v3");
+    expect(items).toContain(result._appendedIds[0]);
+  });
+
+  it("rejects append + value together", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {},
+      value: {
+        schema: "dast",
+        document: { type: "root", children: [{ type: "block", item: "v1" }] },
+      },
+      append: [{ _type: "venue", name: "Messinn", description: "Fish stew" }],
+    });
+    expect(patchRes.status).toBe(400);
+    const body = await patchRes.json();
+    expect(body.error).toContain("Cannot use both 'value' and 'append'");
+  });
+
+  it("rejects append with block missing _type via downstream validation", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {},
+      append: [{ name: "No Type Block" }],
+    });
+    expect(patchRes.status).toBe(400);
+  });
+
+  it("verify appended blocks appear in DB with correct data", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {},
+      append: [{ _type: "venue", name: "Kopar", description: "Harbour restaurant" }],
+    });
+    expect(patchRes.status).toBe(200);
+
+    const result = await patchRes.json();
+    const newId = result._appendedIds[0];
+
+    const blocks = await getBlocks(record.id);
+    const newBlock = blocks.find((b) => b.id === newId);
+    expect(newBlock).toBeDefined();
+    expect(newBlock?.name).toBe("Kopar");
+    expect(newBlock?.description).toBe("Harbour restaurant");
+    expect(newBlock?._root_record_id).toBe(record.id);
+  });
+
+  it("response does not include _appendedIds when no append is used", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      blocks: {
+        v1: { description: "Updated" },
+      },
+    });
+    expect(patchRes.status).toBe(200);
+    const result = await patchRes.json();
+    expect(result._appendedIds).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
- New `append` field on `patch_blocks` accepts an array of block objects (with `_type`)
- Auto-generates block IDs and appends `{ type: "block", item: id }` nodes to DAST
- Mutually exclusive with `value` parameter (clear error message)
- Response includes `_appendedIds` array with generated IDs
- Works alongside existing `blocks` patch map (patch + append in one call)

## Test plan
- [x] Append single block
- [x] Append multiple blocks
- [x] Append + patch existing blocks
- [x] Append + delete existing blocks
- [x] Reject append + value together
- [x] Reject append with missing _type
- [x] Verify appended blocks in DB
- [x] _appendedIds absent when no append used

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)