### PR TITLE
Add order array to patch_blocks for block reordering

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -348,11 +348,16 @@ Optionally provide a new top-level DAST \`value\`. If omitted, the existing DAST
 
 Use \`append\` to insert new blocks without reconstructing the DAST. Each entry is a record with \`_type\` and field values. New block IDs are auto-generated, DAST block nodes are appended to the end, and the response includes \`_appendedIds\`. Cannot be combined with \`value\`.
 
+For blocks_only structured_text fields, you can pass an \`order\` array of block IDs to reorder blocks without constructing a full DAST document. The order array replaces the DAST children list. Cannot be combined with \`value\`. All block IDs in \`order\` must exist in the merged blocks map, and all merged blocks must appear in \`order\`.
+
 Example — update one block's description, delete another, keep the rest:
 { blocks: { "block-2": { "description": "New text" }, "block-3": null } }
 
 Example — append a new block while patching an existing one:
-{ blocks: { "block-2": { "description": "Updated" } }, append: [{ "_type": "venue", "name": "New Place" }] }`, PatchBlocksInput.fields);
+{ blocks: { "block-2": { "description": "Updated" } }, append: [{ "_type": "venue", "name": "New Place" }] }
+
+Example — reorder blocks on a blocks_only field:
+{ order: ["block-3", "block-1", "block-2"], blocks: {} }`, PatchBlocksInput.fields);
 const DeleteRecordTool = cmsTool("delete_record", "Delete a record", DeleteRecordInput.fields);
 const GetRecordTool = cmsTool("get_record", "Get a single record by modelApiKey + recordId. Useful after search_content when you need the full materialized record, including structured_text fields, before patch_blocks or update_record.", GetRecordInput.fields);
 const QueryRecordsTool = cmsTool("query_records", "List records for a model. Structured_text fields are materialized for inspection, including nested blocks inside parent block fields. Useful for finding record IDs before update_record, patch_blocks, set_publish_status, or record_versions.", QueryRecordsInput.fields);

--- a/src/services/input-schemas.ts
+++ b/src/services/input-schemas.ts
@@ -284,6 +284,7 @@ export const PatchBlocksInput = Schema.Struct({
   modelApiKey: Schema.NonEmptyString,
   fieldApiKey: Schema.NonEmptyString,
   value: Schema.optional(Schema.Unknown),
+  order: Schema.optional(Schema.Array(Schema.NonEmptyString)),
   blocks: Schema.Record({ key: Schema.String, value: Schema.NullOr(Schema.Unknown) }),
   append: Schema.optional(Schema.Array(Schema.Record({ key: Schema.String, value: Schema.Unknown }))),
 });

--- a/src/services/record-service.ts
+++ b/src/services/record-service.ts
@@ -1352,7 +1352,31 @@ export function patchBlocksForField(body: PatchBlocksInput, actor?: RequestActor
 
     // Build final DAST value
     let finalDastValue: unknown;
-    if (body.value !== undefined && appendedIds.length > 0) {
+    if (body.order) {
+      // order is only valid on blocks_only fields
+      const blocksOnlyFlag = getBlocksOnly(field.validators);
+      if (!blocksOnlyFlag) {
+        return yield* new ValidationError({
+          message: "The 'order' parameter is only supported on blocks_only structured_text fields. Use the 'value' parameter to provide a custom DAST for mixed prose+block fields.",
+          field: body.fieldApiKey,
+        });
+      }
+      // order and value are mutually exclusive
+      if (body.value !== undefined) {
+        return yield* new ValidationError({
+          message: "Cannot use both 'order' and 'value' — they both control the DAST document structure.",
+          field: body.fieldApiKey,
+        });
+      }
+      // Build DAST from order
+      finalDastValue = {
+        schema: "dast",
+        document: {
+          type: "root",
+          children: body.order.map((id) => ({ type: "block", item: id })),
+        },
+      };
+    } else if (body.value !== undefined && appendedIds.length > 0) {
       return yield* new ValidationError({
         message: "Cannot use both 'value' and 'append' — appended blocks need auto-generated DAST nodes which conflict with a custom DAST value.",
         field: body.fieldApiKey,

--- a/test/patch-blocks-order.test.ts
+++ b/test/patch-blocks-order.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Effect } from "effect";
+import { SqlClient } from "@effect/sql";
+import { createTestApp, jsonRequest } from "./app-helpers.js";
+
+describe("patch_blocks — order array for block reordering", () => {
+  let handler: (req: Request) => Promise<Response>;
+  let sqlLayer: any;
+
+  beforeEach(async () => {
+    ({ handler, sqlLayer } = createTestApp());
+
+    // Block type: section
+    const sectionRes = await jsonRequest(handler, "POST", "/api/models", {
+      name: "Section", apiKey: "section", isBlock: true,
+    });
+    const section = await sectionRes.json();
+    await jsonRequest(handler, "POST", `/api/models/${section.id}/fields`, {
+      label: "Title", apiKey: "title", fieldType: "string",
+    });
+
+    // Content model with blocks_only structured_text field
+    const pageRes = await jsonRequest(handler, "POST", "/api/models", {
+      name: "Page", apiKey: "page", hasDraft: false,
+    });
+    const page = await pageRes.json();
+    await jsonRequest(handler, "POST", `/api/models/${page.id}/fields`, {
+      label: "Name", apiKey: "name", fieldType: "string",
+    });
+    await jsonRequest(handler, "POST", `/api/models/${page.id}/fields`, {
+      label: "Sections", apiKey: "sections", fieldType: "structured_text",
+      validators: {
+        structured_text_blocks: ["section"],
+        blocks_only: true,
+      },
+    });
+
+    // Block type: venue (for mixed content model tests)
+    const venueRes = await jsonRequest(handler, "POST", "/api/models", {
+      name: "Venue", apiKey: "venue", isBlock: true,
+    });
+    const venue = await venueRes.json();
+    await jsonRequest(handler, "POST", `/api/models/${venue.id}/fields`, {
+      label: "Name", apiKey: "name", fieldType: "string",
+    });
+
+    // Content model with non-blocks_only structured_text field
+    const guideRes = await jsonRequest(handler, "POST", "/api/models", {
+      name: "Guide", apiKey: "guide", hasDraft: false,
+    });
+    const guide = await guideRes.json();
+    await jsonRequest(handler, "POST", `/api/models/${guide.id}/fields`, {
+      label: "Title", apiKey: "title", fieldType: "string",
+    });
+    await jsonRequest(handler, "POST", `/api/models/${guide.id}/fields`, {
+      label: "Content", apiKey: "content", fieldType: "structured_text",
+      validators: { structured_text_blocks: ["venue"] },
+    });
+  });
+
+  function getBlocks(tableName: string, recordId: string) {
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        return yield* sql.unsafe<Record<string, unknown>>(
+          `SELECT * FROM "${tableName}" WHERE _root_record_id = ? ORDER BY id`,
+          [recordId]
+        );
+      }).pipe(Effect.provide(sqlLayer))
+    );
+  }
+
+  async function createPageWithSections() {
+    const res = await jsonRequest(handler, "POST", "/api/records", {
+      modelApiKey: "page",
+      data: {
+        name: "My Page",
+        sections: {
+          value: {
+            schema: "dast",
+            document: {
+              type: "root",
+              children: [
+                { type: "block", item: "s1" },
+                { type: "block", item: "s2" },
+                { type: "block", item: "s3" },
+              ],
+            },
+          },
+          blocks: {
+            s1: { _type: "section", title: "Introduction" },
+            s2: { _type: "section", title: "Main Content" },
+            s3: { _type: "section", title: "Conclusion" },
+          },
+        },
+      },
+    });
+    expect(res.status).toBe(201);
+    return res.json();
+  }
+
+  async function createGuideWithVenues() {
+    const res = await jsonRequest(handler, "POST", "/api/records", {
+      modelApiKey: "guide",
+      data: {
+        title: "Food Guide",
+        content: {
+          value: {
+            schema: "dast",
+            document: {
+              type: "root",
+              children: [
+                { type: "block", item: "v1" },
+                { type: "block", item: "v2" },
+              ],
+            },
+          },
+          blocks: {
+            v1: { _type: "venue", name: "Grillid" },
+            v2: { _type: "venue", name: "Dill" },
+          },
+        },
+      },
+    });
+    expect(res.status).toBe(201);
+    return res.json();
+  }
+
+  it("reorders blocks on a blocks_only field", async () => {
+    const record = await createPageWithSections();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "page",
+      fieldApiKey: "sections",
+      order: ["s3", "s1", "s2"],
+      blocks: {},
+    });
+    expect(patchRes.status).toBe(200);
+
+    const updated = await patchRes.json();
+    const sections = typeof updated.sections === "string" ? JSON.parse(updated.sections) : updated.sections;
+    const children = sections.value.document.children;
+    expect(children).toHaveLength(3);
+    expect(children[0].item).toBe("s3");
+    expect(children[1].item).toBe("s1");
+    expect(children[2].item).toBe("s2");
+
+    // All blocks still exist
+    const blocks = await getBlocks("block_section", record.id);
+    expect(blocks).toHaveLength(3);
+  });
+
+  it("rejects order on a non-blocks_only field", async () => {
+    const record = await createGuideWithVenues();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "guide",
+      fieldApiKey: "content",
+      order: ["v2", "v1"],
+      blocks: {},
+    });
+    expect(patchRes.status).toBe(400);
+    const body = await patchRes.json();
+    expect(body.error).toContain("blocks_only");
+  });
+
+  it("rejects order combined with value", async () => {
+    const record = await createPageWithSections();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "page",
+      fieldApiKey: "sections",
+      order: ["s1", "s2", "s3"],
+      value: {
+        schema: "dast",
+        document: {
+          type: "root",
+          children: [{ type: "block", item: "s1" }],
+        },
+      },
+      blocks: {},
+    });
+    expect(patchRes.status).toBe(400);
+    const body = await patchRes.json();
+    expect(body.error).toContain("Cannot use both 'order' and 'value'");
+  });
+
+  it("applies patches and reorders in the same call", async () => {
+    const record = await createPageWithSections();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "page",
+      fieldApiKey: "sections",
+      order: ["s2", "s3", "s1"],
+      blocks: {
+        s1: { title: "Updated Introduction" },
+      },
+    });
+    expect(patchRes.status).toBe(200);
+
+    const updated = await patchRes.json();
+    const sections = typeof updated.sections === "string" ? JSON.parse(updated.sections) : updated.sections;
+
+    // Check order
+    const children = sections.value.document.children;
+    expect(children[0].item).toBe("s2");
+    expect(children[1].item).toBe("s3");
+    expect(children[2].item).toBe("s1");
+
+    // Check patch was applied
+    const blocks = await getBlocks("block_section", record.id);
+    const s1 = blocks.find((b) => b.id === "s1");
+    expect(s1?.title).toBe("Updated Introduction");
+
+    // Other blocks unchanged
+    const s2 = blocks.find((b) => b.id === "s2");
+    expect(s2?.title).toBe("Main Content");
+  });
+
+  it("rejects order with a missing block ID", async () => {
+    const record = await createPageWithSections();
+
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "page",
+      fieldApiKey: "sections",
+      order: ["s1", "s2", "nonexistent"],
+      blocks: {},
+    });
+    expect(patchRes.status).toBe(400);
+  });
+
+  it("rejects order that omits an existing block ID", async () => {
+    const record = await createPageWithSections();
+
+    // Only list s1 and s2, omitting s3
+    const patchRes = await jsonRequest(handler, "PATCH", `/api/records/${record.id}/blocks`, {
+      modelApiKey: "page",
+      fieldApiKey: "sections",
+      order: ["s1", "s2"],
+      blocks: {},
+    });
+    expect(patchRes.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary
- New `order` field on `patch_blocks`: array of block IDs to set DAST order
- Only valid on `blocks_only: true` fields (clear error on mixed fields)
- Mutually exclusive with `value` parameter
- Existing `compileStructuredText` validation catches missing/extra block IDs
- Works alongside `blocks` patches (patch then reorder in one call)

## Test plan
- [x] Reorder blocks on blocks_only field
- [x] Reject order on non-blocks_only field
- [x] Reject order + value together
- [x] Patches + reorder in same call
- [x] Order with missing block ID (errors)
- [x] Order that omits existing block ID (errors)

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)