### PR TITLE
Migrate Next.js example to vinext for Cloudflare Workers

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,31 +1,25 @@
-# Next.js + agent-cms Draft Preview Example
+# vinext + agent-cms Draft Preview Example
 
-Demonstrates draft preview mode with Next.js App Router.
+Demonstrates draft preview mode with vinext (Next.js App Router on Cloudflare Workers).
 
 ## Key files
 
-- `src/app/api/draft-mode/enable/route.ts` — validates preview token against CMS, enables Next.js `draftMode()`, sets `__agentcms_preview` cookie, redirects
-- `src/app/api/draft-mode/disable/route.ts` — disables `draftMode()`, clears cookie
-- `src/lib/cms.ts` — GraphQL client that forwards preview token as `X-Preview-Token` and bypasses Next.js data cache when in preview mode
+- `src/app/api/draft-mode/enable/route.ts` — validates preview token against CMS, sets `__agentcms_preview` cookie, redirects
+- `src/app/api/draft-mode/disable/route.ts` — clears cookie, redirects
+- `src/lib/cms.ts` — GraphQL client that forwards preview token as `X-Preview-Token`
 - `src/app/posts/[slug]/page.tsx` — post page with multi-root GraphQL query (fetches post + site settings in one request), shows "Draft" badge for unpublished content
-- `src/components/preview-bar.tsx` — server component that shows a fixed "Draft Preview" bar when `draftMode().isEnabled`
+- `src/components/preview-bar.tsx` — server component that shows a fixed "Draft Preview" bar when the preview cookie is set
+- `worker/index.ts` — Cloudflare Worker entry point, copies env vars to `process.env`
+- `vite.config.ts` — Vite config with vinext and Cloudflare plugins
 
 ## How preview works
 
-1. Agent creates a draft via MCP → gets `_previewPath`
-2. Agent calls `get_preview_url` → gets fully assembled URL like `https://mysite.com/api/draft-mode/enable?token=pvt_...&redirect=/posts/my-draft`
+1. Agent creates a draft via MCP, gets `_previewPath`
+2. Agent calls `get_preview_url`, gets fully assembled URL like `https://mysite.com/api/draft-mode/enable?token=pvt_...&redirect=/posts/my-draft`
 3. User clicks the link
-4. Enable route validates token, calls `draftMode().enable()`, sets cookie, redirects
-5. Page fetches with `X-Preview-Token` header → CMS returns draft content
+4. Enable route validates token, sets `__agentcms_preview` cookie, redirects
+5. Page reads the cookie and fetches with `X-Preview-Token` header — CMS returns draft content
 6. `PreviewBar` component shows "Draft Preview" with exit link
-
-## Next.js-specific details
-
-- `draftMode().enable()` is required — it sets Next.js's `__prerender_bypass` cookie which bypasses ISR and static generation
-- The `__agentcms_preview` cookie stores the actual CMS token (separate from Next.js's bypass cookie)
-- `SameSite=None; Secure` on the CMS cookie for iframe compatibility
-- `cache: "no-store"` on GraphQL fetches when preview token is present — bypasses Next.js data cache
-- The `PreviewBar` is a server component that reads `draftMode()` directly
 
 ## Setup
 
@@ -33,5 +27,14 @@ Demonstrates draft preview mode with Next.js App Router.
 pnpm install
 CMS_URL=http://localhost:8787 pnpm dev
 ```
+
+## Deploy to Cloudflare Workers
+
+```bash
+pnpm build
+wrangler deploy
+```
+
+Set `CMS_URL` in `wrangler.jsonc` vars or via `wrangler secret put CMS_URL` for production.
 
 The CMS must be running with a schema that has `canonicalPathTemplate` set on your models.

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -2,10 +2,12 @@
   "name": "agent-cms-nextjs-example",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
+    "dev": "vinext dev",
+    "build": "vite build",
+    "start": "vinext start",
+    "deploy": "vite build && wrangler deploy",
     "introspect": "gql.tada generate-schema 'http://localhost:8787/graphql' --output ./schema.graphql",
     "generate": "gql.tada generate-output",
     "graphql:check": "gql.tada check"
@@ -13,8 +15,14 @@
   "dependencies": {
     "gql.tada": "^1.8.0",
     "graphql": "^16.13.1",
-    "next": "^15.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "vinext": "^0.0.29"
+  },
+  "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.30.0",
+    "typescript": "^5.9.3",
+    "vite": "^8.0.1",
+    "wrangler": "^4.76.0"
   }
 }

--- a/examples/nextjs/src/app/api/draft-mode/disable/route.ts
+++ b/examples/nextjs/src/app/api/draft-mode/disable/route.ts
@@ -1,17 +1,12 @@
-import { draftMode } from "next/headers";
-import { NextRequest } from "next/server";
-
 /**
  * Disable draft preview mode.
  *
  * GET /api/draft-mode/disable?redirect=/
  */
-export async function GET(request: NextRequest) {
-  const rawRedirect = request.nextUrl.searchParams.get("redirect") ?? "/";
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const rawRedirect = url.searchParams.get("redirect") ?? "/";
   const redirectPath = safePath(rawRedirect);
-
-  const draft = await draftMode();
-  draft.disable();
 
   return new Response(null, {
     status: 307,

--- a/examples/nextjs/src/app/api/draft-mode/enable/route.ts
+++ b/examples/nextjs/src/app/api/draft-mode/enable/route.ts
@@ -1,7 +1,3 @@
-import { draftMode } from "next/headers";
-import { redirect } from "next/navigation";
-import { NextRequest } from "next/server";
-
 const CMS_URL = process.env.CMS_URL ?? "http://localhost:8787";
 
 /**
@@ -9,12 +5,13 @@ const CMS_URL = process.env.CMS_URL ?? "http://localhost:8787";
  *
  * GET /api/draft-mode/enable?token=pvt_...&redirect=/posts/my-draft
  *
- * Validates the preview token against the CMS, enables Next.js draftMode(),
- * sets the CMS preview cookie, and redirects to the content page.
+ * Validates the preview token against the CMS, sets the __agentcms_preview
+ * cookie, and redirects to the content page.
  */
-export async function GET(request: NextRequest) {
-  const token = request.nextUrl.searchParams.get("token");
-  const rawRedirect = request.nextUrl.searchParams.get("redirect") ?? "/";
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token");
+  const rawRedirect = url.searchParams.get("redirect") ?? "/";
 
   if (!token) {
     return new Response("Missing token parameter", { status: 400 });
@@ -26,23 +23,23 @@ export async function GET(request: NextRequest) {
   const res = await fetch(
     `${CMS_URL}/api/preview-tokens/validate?token=${encodeURIComponent(token)}`,
   );
-  const body = await res.json() as { valid: boolean; expiresAt?: string };
+  const body = (await res.json()) as { valid: boolean; expiresAt?: string };
 
   if (!body.valid) {
     return new Response("Invalid or expired preview token", { status: 401 });
   }
 
-  // Enable Next.js draft mode (sets __prerender_bypass cookie)
-  const draft = await draftMode();
-  draft.enable();
-
-  // Also set the CMS preview cookie so our GraphQL client can read it
   const maxAge = body.expiresAt
-    ? Math.max(0, Math.floor((new Date(body.expiresAt).getTime() - Date.now()) / 1000))
+    ? Math.max(
+        0,
+        Math.floor(
+          (new Date(body.expiresAt).getTime() - Date.now()) / 1000,
+        ),
+      )
     : 86400;
 
-  // Redirect with the CMS cookie
-  const response = new Response(null, {
+  // Redirect with the CMS preview cookie
+  return new Response(null, {
     status: 307,
     headers: {
       Location: redirectPath,
@@ -50,8 +47,6 @@ export async function GET(request: NextRequest) {
       "Set-Cookie": `__agentcms_preview=${token}; Path=/; HttpOnly; SameSite=None; Secure; Max-Age=${maxAge}`,
     },
   });
-
-  return response;
 }
 
 function safePath(raw: string): string {

--- a/examples/nextjs/src/app/posts/[slug]/page.tsx
+++ b/examples/nextjs/src/app/posts/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { draftMode, cookies } from "next/headers";
+import { cookies } from "next/headers";
 import { notFound } from "next/navigation";
 import { cmsQuery } from "../../../lib/cms";
 import { POST_PAGE_QUERY } from "../../../graphql/queries";
@@ -17,16 +17,10 @@ export default async function PostPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const draft = await draftMode();
-  const previewToken = draft.isEnabled
-    ? (await cookies()).get("__agentcms_preview")?.value
-    : undefined;
+  const cookieStore = await cookies();
+  const previewToken = cookieStore.get("__agentcms_preview")?.value;
 
-  const data = await cmsQuery(
-    POST_PAGE_QUERY,
-    { slug },
-    { previewToken },
-  );
+  const data = await cmsQuery(POST_PAGE_QUERY, { slug }, { previewToken });
 
   if (!data.post) notFound();
 
@@ -50,7 +44,13 @@ export default async function PostPage({
               {post.category.name}
             </a>
           )}
-          <h1 style={{ fontSize: "2.5rem", lineHeight: 1.2, margin: "0.5rem 0 1rem" }}>
+          <h1
+            style={{
+              fontSize: "2.5rem",
+              lineHeight: 1.2,
+              margin: "0.5rem 0 1rem",
+            }}
+          >
             {post.title}
           </h1>
           {post._status === "draft" && (
@@ -67,7 +67,15 @@ export default async function PostPage({
               Draft
             </span>
           )}
-          <div style={{ display: "flex", gap: "1.5rem", fontSize: "0.9rem", color: "#666", marginTop: "0.5rem" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: "1.5rem",
+              fontSize: "0.9rem",
+              color: "#666",
+              marginTop: "0.5rem",
+            }}
+          >
             {post.author && <span>{post.author.name}</span>}
             {post.publishedDate && (
               <time dateTime={post.publishedDate}>

--- a/examples/nextjs/src/components/preview-bar.tsx
+++ b/examples/nextjs/src/components/preview-bar.tsx
@@ -1,12 +1,13 @@
-import { draftMode } from "next/headers";
+import { cookies } from "next/headers";
 
 /**
  * Fixed bar at the bottom of the page when draft mode is active.
- * Server component — reads draftMode() directly.
+ * Server component — reads the __agentcms_preview cookie directly.
  */
 export async function PreviewBar() {
-  const draft = await draftMode();
-  if (!draft.isEnabled) return null;
+  const cookieStore = await cookies();
+  const previewCookie = cookieStore.get("__agentcms_preview");
+  if (!previewCookie?.value) return null;
 
   return (
     <div

--- a/examples/nextjs/src/lib/cms.ts
+++ b/examples/nextjs/src/lib/cms.ts
@@ -1,8 +1,7 @@
 /**
  * Type-safe GraphQL client for agent-cms using gql.tada.
  *
- * When a preview token is provided, it's sent as X-Preview-Token
- * and the response bypasses all caches.
+ * When a preview token is provided, it's sent as X-Preview-Token.
  */
 
 import type { TadaDocumentNode } from "gql.tada";
@@ -31,9 +30,6 @@ export async function cmsQuery<TResult, TVariables>(
     method: "POST",
     headers,
     body: JSON.stringify({ query: print(document), variables: variables ?? {} }),
-    // Bypass Next.js data cache in preview mode
-    cache: options?.previewToken ? "no-store" : "force-cache",
-    next: options?.previewToken ? { revalidate: 0 } : { revalidate: 60 },
   });
 
   if (!res.ok) {

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -1,5 +1,18 @@
 {
   "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "target": "ES2017",
     "plugins": [
       {
         "name": "gql.tada/ts-plugin",
@@ -7,5 +20,7 @@
         "tadaOutputLocation": "./src/graphql/graphql-env.d.ts"
       }
     ]
-  }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
 }

--- a/examples/nextjs/vite.config.ts
+++ b/examples/nextjs/vite.config.ts
@@ -1,0 +1,19 @@
+import { cloudflare } from "@cloudflare/vite-plugin";
+import vinext from "vinext";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    vinext(),
+    cloudflare({
+      viteEnvironment: {
+        name: "rsc",
+        childEnvironments: ["ssr"],
+      },
+    }),
+  ],
+  environments: {
+    rsc: { optimizeDeps: { include: ["cssom"] } },
+    ssr: { optimizeDeps: { include: ["cssom"] } },
+  },
+});

--- a/examples/nextjs/worker/index.ts
+++ b/examples/nextjs/worker/index.ts
@@ -1,0 +1,16 @@
+import handler from "vinext/server/app-router-entry";
+
+interface Env {
+  [key: string]: unknown;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === "string") {
+        process.env[key] = value;
+      }
+    }
+    return handler.fetch(request);
+  },
+};

--- a/examples/nextjs/wrangler.jsonc
+++ b/examples/nextjs/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "name": "agent-cms-nextjs-example",
+  "compatibility_date": "2026-02-28",
+  "compatibility_flags": ["nodejs_compat"],
+  "main": "./worker/index.ts",
+  "vars": {
+    "CMS_URL": "http://localhost:8787"
+  },
+  "assets": {
+    "not_found_handling": "none",
+    "directory": "dist/client"
+  }
+}


### PR DESCRIPTION
## Summary

Replaces `next` with `vinext` so the Next.js example deploys to Cloudflare Workers. The app structure (App Router) stays the same — vinext is a Vite-based implementation of Next.js App Router that runs on Workers.

### Changes
- **Dependencies**: `next` → `vinext` + `vite` + `@cloudflare/vite-plugin` + `wrangler`
- **Build**: `vinext dev` / `vite build` / `wrangler deploy`
- **New files**: `vite.config.ts`, `wrangler.jsonc`, `worker/index.ts`
- **Draft preview**: Cookie-based (`__agentcms_preview`) instead of Next.js `draftMode()` API
- **Fetch**: Removed Next.js-specific `cache` and `next` options
- **gql.tada**: All typed GraphQL setup preserved (queries, fragments, schema)

## Test plan
- [ ] `pnpm install` succeeds
- [ ] `pnpm run dev` starts vinext dev server
- [ ] `pnpm run build` produces dist/client
- [ ] Draft preview enable/disable works via cookies
- [ ] Post page renders with typed GraphQL data

🤖 Generated with [Claude Code](https://claude.com/claude-code)